### PR TITLE
Expose ports to Dockerfiles

### DIFF
--- a/docker/drill/Dockerfile
+++ b/docker/drill/Dockerfile
@@ -34,6 +34,10 @@ RUN rm -f /tmp/apache-drill-$VERSION.tar.gz
 RUN chgrp -v -R drill /opt/drill
 RUN chown -R drill /opt/drill/conf 
 
+# Expose ports: Drill web UI, user port, control port and Data port
+# https://drill.apache.org/docs/ports-and-bind-addresses-used-by-drill/
+EXPOSE 8047 31010 31011 31012
+
 # Test Drill
 #RUN echo "select * from sys.version;" > /tmp/version.sql
 #RUN /opt/drill/bin/sqlline -u jdbc:drill:zk=local --verbose --run=/tmp/version.sql

--- a/docker/zookeeper/Dockerfile
+++ b/docker/zookeeper/Dockerfile
@@ -36,6 +36,9 @@ COPY zoo.cfg /opt/zookeeper/conf/zoo.cfg
 # Set logs in /var/logs
 ENV ZOO_LOG_DIR=/var/log/zookeeper 
 
+## Expose client, server and leader-election ports on container
+EXPOSE 2181 2888 3888
+
 # Start ZooKeeper
 COPY start.sh /opt/zookeeper/start.sh
 


### PR DESCRIPTION
The dockerfile exposes the ports. Useful if someone is using docker-compose or just docker for testing.